### PR TITLE
Dont hardcode wheels version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
       
       - name: Run sample demo in clean environment
         run: |
-          pip install ./wheels/linux/jecq-0.0.1-py3-none-any.whl
+          pip install "$(ls ./wheels/linux/jecq-*.whl | head -n1)"
           pip install -r ./demos/requirements.txt
           # Run demo script
           python3 ./demos/demo_sample_search.py
@@ -162,10 +162,10 @@ jobs:
         run: |
           echo "Listing wheels-linux:"
           ls -l wheels-linux
-          mv wheels-linux/jecq-0.0.1-py3-none-any.whl wheels-linux/jecq-linux.whl
+          mv wheels-linux/jecq-*.whl wheels-linux/jecq-linux.whl
           echo "Listing wheels-windows:"
           ls -l wheels-windows
-          mv wheels-windows/jecq-0.0.1-py3-none-any.whl wheels-windows/jecq-windows.whl
+          mv wheels-windows/jecq-*.whl wheels-windows/jecq-windows.whl
 
       - name: Create draft release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
Allow wheels files to have versions in them without breaking GitHub workflows